### PR TITLE
Box2 far coordinate getters

### DIFF
--- a/include/rlm/cellular/coordinates.hpp
+++ b/include/rlm/cellular/coordinates.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef RLM_CELLULAR_COORDINATES_HPP
+#define RLM_CELLULAR_COORDINATES_HPP
+
+#include <rlm/concepts.hpp>
+
+namespace rl
+{
+    template <rl::signed_integral I>
+    struct box2;
+
+    template<rl::signed_integral I = int>
+    constexpr I far_x(const rl::box2<I>& box) noexcept;
+
+    template<rl::signed_integral I = int>
+    constexpr I far_y(const rl::box2<I>& box) noexcept;
+}
+
+#include <rlm/cellular/detail/coordinates.inl>
+
+#endif

--- a/include/rlm/cellular/detail/coordinates.inl
+++ b/include/rlm/cellular/detail/coordinates.inl
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef RLM_CELLULAR_COORDINATES_INL
+#define RLM_CELLULAR_COORDINATES_INL
+
+#include <rlm/concepts.hpp>
+#include <rlm/cellular/box2.hpp>
+#include <rlm/cellular/is_degenerate.hpp>
+#include <cassert>
+
+template<rl::signed_integral I>
+constexpr I rl::far_x(const rl::box2<I>& box) noexcept
+{
+    assert(!rl::is_degenerate(box) && "getting far_x of degenerate box2");
+    return box.x + box.width - 1;
+}
+
+template<rl::signed_integral I>
+constexpr I rl::far_y(const rl::box2<I>& box) noexcept
+{
+    assert(!rl::is_degenerate(box) && "getting far_y of degenerate box2");
+    return box.y + box.height - 1;
+}
+
+#endif

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(RlmTest
     PRIVATE
         "cellular_box2_tests.cpp"
         "cellular_circle2_tests.cpp"
+        "cellular_coordinates_tests.cpp"
         "cellular_direction_tests.cpp"
         "cellular_is_degenerate_tests.cpp"
         "cellular_point2_tests.cpp"

--- a/test/src/cellular_coordinates_tests.cpp
+++ b/test/src/cellular_coordinates_tests.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/cellular/box2.hpp>
+#include <rlm/cellular/coordinates.hpp>
+
+SCENARIO("The far coordinates are gotten from a box2")
+{
+    GIVEN("A box2")
+    {
+        const rl::box2 box(1, 2, 3, 4);
+        THEN("The far coordinates are correct")
+        {
+            CHECK(rl::far_x(box) == 3);
+            CHECK(rl::far_y(box) == 5);
+        }
+    }
+}


### PR DESCRIPTION
<!--

NOTICE:

This is a template for a pull request. Please replace the text in each section with your own explanations.

For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.

While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.

This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

-->

# Description of Changes

Add functions for getting the far x and y coordinates of a box2.

# Closing Issues

Closes #43
