### PR TITLE
Remove header comment from pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,3 @@
-<!--
-
-NOTICE:
-
-This is a template for a pull request. Please replace the text in each section with your own explanations.
-
-For more information about contributing to our project, please view our Contributing Guidelines in the CONTRIBUTING.md file in the root directory of the code repository.
-
-While you participate in our community, you must follow our Code of Conduct in the CODE_OF_CONDUCT.md file in the root directory of the code repository.
-
-This entry field uses Markdown syntax for advanced text formatting. If you would like to preview how this post will appear with Markdown applied, click the preview tab above. You can read about Markdown syntax in the official GitHub documentation website:
-
-https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
-
--->
-
 # Description of Changes
 
 Replace this text with a detailed description of what what changes are commited within this pull request.


### PR DESCRIPTION
Removing it because it made the template harder to work with. Now, you don't have to scroll down to find the place to type the pull request.
