### PR TITLE
Remove the unused cell_vector2_or_cell_segment2 concept

### DIFF
--- a/include/rlm/cellular/concepts.hpp
+++ b/include/rlm/cellular/concepts.hpp
@@ -34,7 +34,4 @@ namespace rl
     template<typename T, typename I, typename F>
     concept cellular_shape =
         rl::is_any_of<T, rl::cell_vector2<I>, rl::cell_segment2<I>, rl::cell_box2<I>, rl::cell_circle2<I, F>>;
-
-    template<typename T, typename I>
-    concept cell_vector2_or_cell_segment2 = rl::is_any_of<T, rl::cell_vector2<I>, rl::cell_segment2<I>>;
 }    // namespace rl


### PR DESCRIPTION
Remove it because it has a really long name and not used anywhere.