### PR TITLE
Cell walk funcs

### DIFF
--- a/include/rlm/cellular/detail/shape_edges.inl
+++ b/include/rlm/cellular/detail/shape_edges.inl
@@ -86,27 +86,27 @@ template<rl::signed_integral I, rl::floating_point F>
 constexpr I rl::left_x(const rl::cell_circle2<I, F>& circle) noexcept
 {
     RLM_HANDLE_DEGENERACY(fixed_circle, circle);
-    return fixed_circle.x - static_cast<I>(std::round(fixed_circle.radius)) + 1;
+    return fixed_circle.x - static_cast<I>(std::round(fixed_circle.radius));
 }
 
 template<rl::signed_integral I, rl::floating_point F>
 constexpr I rl::right_x(const rl::cell_circle2<I, F>& circle) noexcept
 {
     RLM_HANDLE_DEGENERACY(fixed_circle, circle);
-    return fixed_circle.x + static_cast<I>(std::round(fixed_circle.radius)) - 1;
+    return fixed_circle.x + static_cast<I>(std::round(fixed_circle.radius));
 }
 
 template<rl::signed_integral I, rl::floating_point F>
 constexpr I rl::top_y(const rl::cell_circle2<I, F>& circle) noexcept
 {
     RLM_HANDLE_DEGENERACY(fixed_circle, circle);
-    return fixed_circle.y - static_cast<I>(std::round(fixed_circle.radius)) + 1;
+    return fixed_circle.y - static_cast<I>(std::round(fixed_circle.radius));
 }
 
 template<rl::signed_integral I, rl::floating_point F>
 constexpr I rl::bottom_y(const rl::cell_circle2<I, F>& circle) noexcept
 {
     RLM_HANDLE_DEGENERACY(fixed_circle, circle);
-    return fixed_circle.y + static_cast<I>(std::round(fixed_circle.radius)) - 1;
+    return fixed_circle.y + static_cast<I>(std::round(fixed_circle.radius));
 }
 

--- a/include/rlm/cellular/detail/walk.inl
+++ b/include/rlm/cellular/detail/walk.inl
@@ -47,7 +47,7 @@ constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicat
 {
     for (I cell_i = 0; cell_i < rl::diagonal_length<I>(segment); cell_i++)
     {
-        F percent = static_cast<F>(rl::diagonal_length<I>(segment)) / static_cast<F>(cell_i);
+        const F percent = static_cast<F>(rl::diagonal_length<I>(segment)) / static_cast<F>(cell_i);
         predicate(
             rl::lerp<I, F>(
                 segment,

--- a/include/rlm/cellular/detail/walk.inl
+++ b/include/rlm/cellular/detail/walk.inl
@@ -31,6 +31,8 @@
 #include <rlm/cellular/lerp.hpp>
 #include <rlm/cellular/shape_edges.hpp>
 #include <rlm/cellular/cell_circle2_size.hpp>
+#include <rlm/configuration.hpp>
+#include <rlm/cellular/degenerate_shapes.hpp>
 #include <functional>
 #include <cmath>
 
@@ -58,9 +60,10 @@ constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicat
 template<rl::signed_integral I, rl::signed_integral F>
 constexpr void walk(const rl::cell_box2<I>& box, const rl::walk_predicate<I>& predicate)
 {
-    for (I cell_y = rl::top_y(box); cell_y <= rl::bottom_y(box); cell_y++)
+    RLM_HANDLE_DEGENERACY(fixed_box, box);
+    for (I cell_y = rl::top_y(fixed_box); cell_y <= rl::bottom_y(fixed_box); cell_y++)
     {
-        for (I cell_x = rl::left_x(box); cell_x <= rl::right_x(box); cell_x++)
+        for (I cell_x = rl::left_x(fixed_box); cell_x <= rl::right_x(fixed_box); cell_x++)
         {
             predicate(
                 rl::cell_vector2<I>(
@@ -75,32 +78,32 @@ constexpr void walk(const rl::cell_box2<I>& box, const rl::walk_predicate<I>& pr
 template<rl::signed_integral I, rl::signed_integral F>
 constexpr void walk(const rl::cell_circle2<I, F>& circle, const rl::walk_predicate<I>& predicate)
 {
-
-    for (I offset_y = 1; offset_y <= rl::cell_radius(circle); offset_y++)
+    RLM_HANDLE_DEGENERACY(fixed_circle, circle);
+    for (I offset_y = 1; offset_y <= rl::cell_radius(fixed_circle); offset_y++)
     {
-        offset_x = std::floor(std::sqrt(circle.radius * circle.radius - offset_y * offset_y));
-        for (I cell_x = circle.x - offset_x; cell_x <= circle.x + offset_x; cell_x++)
+        offset_x = std::floor(std::sqrt(fixed_circle.radius * fixed_circle.radius - offset_y * offset_y));
+        for (I cell_x = fixed_circle.x - offset_x; cell_x <= fixed_circle.x + offset_x; cell_x++)
         {
             predicate(
                 rl::cell_vector2<I>(
                     cell_x,
-                    circle.y - offset_y
+                    fixed_circle.y - offset_y
                 )
             );
             predicate(
                 rl::cell_vector2<I>(
                     cell_x,
-                    circle.y + offset_y
+                    fixed_circle.y + offset_y
                 )
             );
         }
     }
-    for (I cell_x = rl::right_x<I, F>(circle); cell_x <= rl::right_x<I, F>(circle); cell_x++)
+    for (I cell_x = rl::right_x<I, F>(fixed_circle); cell_x <= rl::right_x<I, F>(fixed_circle); cell_x++)
     {
         predicate(
             rl::cell_vector2<I>(
                 cell_x,
-                circle.y
+                fixed_circle.y
             )
         );
     }

--- a/include/rlm/cellular/detail/walk.inl
+++ b/include/rlm/cellular/detail/walk.inl
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/concepts.hpp>
+#include <rlm/cellular/cell_vector2.hpp>
+#include <rlm/cellular/cell_segment2.hpp>
+#include <rlm/cellular/cell_box2.hpp>
+#include <rlm/cellular/cell_circle2.hpp>
+#include <rlm/cellular/cell_segment2_size.hpp>
+#include <rlm/cellular/lerp.hpp>
+#include <rlm/cellular/shape_edges.hpp>
+#include <rlm/cellular/cell_circle2_size.hpp>
+#include <functional>
+#include <cmath>
+
+template<rl::signed_integral I, rl::signed_integral F>
+constexpr void walk(const rl::cell_vector2<I>& vector, const rl::walk_predicate<I>& predicate)
+{
+    predicate(vector);
+}
+
+template<rl::signed_integral I, rl::signed_integral F>
+constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicate<I>& predicate)
+{
+    for (I cell_i = 0; cell_i < rl::diagonal_length<I>(segment); cell_i++)
+    {
+        F percent = static_cast<F>(rl::diagonal_length<I>(segment)) / static_cast<F>(cell_i);
+        predicate(
+            rl::lerp<I, F>(
+                segment,
+                percent
+            )
+        );
+    }
+}
+
+template<rl::signed_integral I, rl::signed_integral F>
+constexpr void walk(const rl::cell_box2<I>& box, const rl::walk_predicate<I>& predicate)
+{
+    for (I cell_y = rl::top_y(box); cell_y <= rl::bottom_y(box); cell_y++)
+    {
+        for (I cell_x = rl::left_x(box); cell_x <= rl::right_x(box); cell_x++)
+        {
+            predicate(
+                rl::cell_vector2<I>(
+                    cell_x,
+                    cell_y
+                )
+            );
+        }
+    }
+}
+
+template<rl::signed_integral I, rl::signed_integral F>
+constexpr void walk(const rl::cell_circle2<I, F>& circle, const rl::walk_predicate<I>& predicate)
+{
+
+    for (I offset_y = 1; offset_y <= rl::cell_radius(circle); offset_y++)
+    {
+        offset_x = std::floor(std::sqrt(circle.radius * circle.radius - offset_y * offset_y));
+        for (I cell_x = circle.x - offset_x; cell_x <= circle.x + offset_x; cell_x++)
+        {
+            predicate(
+                rl::cell_vector2<I>(
+                    cell_x,
+                    circle.y - offset_y
+                )
+            );
+            predicate(
+                rl::cell_vector2<I>(
+                    cell_x,
+                    circle.y + offset_y
+                )
+            );
+        }
+    }
+    for (I cell_x = rl::right_x<I, F>(circle); cell_x <= rl::right_x<I, F>(circle); cell_x++)
+    {
+        predicate(
+            rl::cell_vector2<I>(
+                cell_x,
+                circle.y
+            )
+        );
+    }
+}

--- a/include/rlm/cellular/detail/walk.inl
+++ b/include/rlm/cellular/detail/walk.inl
@@ -35,9 +35,9 @@
 #include <cmath>
 
 template<rl::signed_integral I, rl::signed_integral F>
-constexpr void walk(const rl::cell_vector2<I>& vector, const rl::walk_predicate<I>& predicate)
+constexpr void walk(const rl::cell_vector2<I>& point, const rl::walk_predicate<I>& predicate)
 {
-    predicate(vector);
+    predicate(point);
 }
 
 template<rl::signed_integral I, rl::signed_integral F>

--- a/include/rlm/cellular/detail/walk.inl
+++ b/include/rlm/cellular/detail/walk.inl
@@ -81,7 +81,7 @@ constexpr void walk(const rl::cell_circle2<I, F>& circle, const rl::walk_predica
     RLM_HANDLE_DEGENERACY(fixed_circle, circle);
     for (I offset_y = 1; offset_y <= rl::cell_radius(fixed_circle); offset_y++)
     {
-        offset_x = std::floor(std::sqrt(fixed_circle.radius * fixed_circle.radius - offset_y * offset_y));
+        const I offset_x = static_cast<I>(std::floor(std::sqrt(fixed_circle.radius * fixed_circle.radius - offset_y * offset_y)));
         for (I cell_x = fixed_circle.x - offset_x; cell_x <= fixed_circle.x + offset_x; cell_x++)
         {
             predicate(

--- a/include/rlm/cellular/walk.hpp
+++ b/include/rlm/cellular/walk.hpp
@@ -40,7 +40,7 @@ namespace rl
     using walk_predicate = std::function<void(const rl::cell_vector2<I>& step)>;
 
     template<rl::signed_integral I = int, rl::signed_integral F = float>
-    constexpr void walk(const rl::cell_vector2<I>& vector, const rl::walk_predicate<I>& predicate);
+    constexpr void walk(const rl::cell_vector2<I>& point, const rl::walk_predicate<I>& predicate);
 
     template<rl::signed_integral I = int, rl::signed_integral F = float>
     constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicate<I>& predicate);

--- a/include/rlm/cellular/walk.hpp
+++ b/include/rlm/cellular/walk.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/concepts.hpp>
+#include <functional>
+
+namespace rl
+{
+    template<rl::signed_integral I = int>
+    struct cell_vector2;
+    template<rl::signed_integral I = int>
+    struct cell_segment2;
+    template<rl::signed_integral I = int>
+    struct cell_box2;
+    template<rl::signed_integral I = int, rl::floating_point F = float>
+    struct cell_circle2;
+
+    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    using walk_predicate = std::function<void(const rl::cell_vector2<I>& step)>;
+
+    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    constexpr void walk(const rl::cell_vector2<I>& vector, const rl::walk_predicate<I>& predicate);
+
+    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicate<I>& predicate);
+
+    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    constexpr void walk(const rl::cell_box2<I>& box, const rl::walk_predicate<I>& predicate);
+
+    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    constexpr void walk(const rl::cell_circle2<I, F>& circle, const rl::walk_predicate<I>& predicate);
+}

--- a/include/rlm/cellular/walk.hpp
+++ b/include/rlm/cellular/walk.hpp
@@ -27,27 +27,29 @@
 
 namespace rl
 {
-    template<rl::signed_integral I = int>
+    template<rl::signed_integral I>
     struct cell_vector2;
-    template<rl::signed_integral I = int>
+    template<rl::signed_integral I>
     struct cell_segment2;
-    template<rl::signed_integral I = int>
+    template<rl::signed_integral I>
     struct cell_box2;
-    template<rl::signed_integral I = int, rl::floating_point F = float>
+    template<rl::signed_integral I, rl::floating_point F>
     struct cell_circle2;
 
-    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    template<rl::signed_integral I = int>
     using walk_predicate = std::function<void(const rl::cell_vector2<I>& step)>;
 
-    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    template<rl::signed_integral I = int, rl::floating_point F = float>
     constexpr void walk(const rl::cell_vector2<I>& point, const rl::walk_predicate<I>& predicate);
 
-    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    template<rl::signed_integral I = int, rl::floating_point F = float>
     constexpr void walk(const rl::cell_segment2<I>& segment, const rl::walk_predicate<I>& predicate);
 
-    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    template<rl::signed_integral I = int, rl::floating_point F = float>
     constexpr void walk(const rl::cell_box2<I>& box, const rl::walk_predicate<I>& predicate);
 
-    template<rl::signed_integral I = int, rl::signed_integral F = float>
+    template<rl::signed_integral I = int, rl::floating_point F = float>
     constexpr void walk(const rl::cell_circle2<I, F>& circle, const rl::walk_predicate<I>& predicate);
 }
+
+#include <rlm/cellular/detail/walk.inl>

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -51,6 +51,7 @@ target_sources(RlmTest
         "cellular_cell_segment2_tests.cpp"
         "cellular_shape_points_tests.cpp"
         "cellular_translation_tests.cpp"
+        "cellular_walk_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"
         "lerp_tests.cpp"

--- a/test/src/cellular_bounding_cell_box2_tests.cpp
+++ b/test/src/cellular_bounding_cell_box2_tests.cpp
@@ -55,7 +55,7 @@ SCENARIO("Get the bounding cell_box2 of cell shapes")
         const rl::cell_circle2 circle(1, 2, 3.0f);
         THEN("The bounding cell_box2 is correct")
         {
-            CHECK(rl::bounding_cell_box2(circle) == rl::cell_box2(-1, 0, 6, 6));
+            CHECK(rl::bounding_cell_box2(circle) == rl::cell_box2(-2, -1, 6, 6));
         }
     }
     GIVEN("A cell_vector2, cell_segment2, cell_box2, and cell_circle2")
@@ -66,7 +66,7 @@ SCENARIO("Get the bounding cell_box2 of cell shapes")
         const rl::cell_circle2 circle(-50, 0, 3.0f);
         THEN("The bounding cell_box2 is correct")
         {
-            CHECK(rl::bounding_cell_box2(point, segment, box, circle) == rl::cell_box2(-52, 54, 107, 115));
+            CHECK(rl::bounding_cell_box2(point, segment, box, circle) == rl::cell_box2(-53, 54, 108, 116));
         }
     }
 }

--- a/test/src/cellular_does_contain_tests.cpp
+++ b/test/src/cellular_does_contain_tests.cpp
@@ -223,7 +223,7 @@ SCENARIO("It is determined if a cell_box2 contains other cell shapes")
         }
         GIVEN("A cell_circle2 that is within the cell_box2")
         {
-            const rl::cell_circle2 circle(1, 1, 0.5f);
+            const rl::cell_circle2 circle(2, 2, 0.5f);
             THEN("The cell_circle2 is within the cell_box2")
             {
                 CHECK(rl::does_contain(box, circle));

--- a/test/src/cellular_shape_edges_tests.cpp
+++ b/test/src/cellular_shape_edges_tests.cpp
@@ -61,10 +61,10 @@ SCENARIO("The edge coordinates are gotten from a cirlce2")
         const rl::cell_circle2 circle(1, 2, 0.5f);
         THEN("The edge coordinates are correct")
         {
-            CHECK(rl::left_x(circle) == 1);
-            CHECK(rl::right_x(circle) == 1);
-            CHECK(rl::top_y(circle) == 2);
-            CHECK(rl::bottom_y(circle) == 2);
+            CHECK(rl::left_x(circle) == 0);
+            CHECK(rl::right_x(circle) == 2);
+            CHECK(rl::top_y(circle) == 1);
+            CHECK(rl::bottom_y(circle) == 3);
         }
     }
 }

--- a/test/src/cellular_walk_tests.cpp
+++ b/test/src/cellular_walk_tests.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/cellular/walk.hpp>
+#include <rlm/cellular/cell_vector2.hpp>
+#include <rlm/cellular/ostream.hpp>
+#include <vector>
+#include <algorithm>
+
+SCENARIO("A cell_vector2 is walked over")
+{
+    std::vector<rl::cell_vector2<int>> traversed_points;
+    GIVEN("A cell_vector2")
+    {
+        const rl::cell_vector2 point(1, 1);
+        WHEN("The cell_vector2 is walked over")
+        {
+            rl::walk<int>(
+                point,
+                [&](const rl::cell_vector2<int>& step)
+                {
+                    traversed_points.push_back(step);
+                }
+            );
+            THEN("The walked over points are correct")
+            {
+                std::vector<rl::cell_vector2<int>> correct_points =
+                    {
+                        rl::cell_vector2(1, 1)
+                    };
+                CHECK(
+                    std::equal(
+                        traversed_points.begin(),
+                        traversed_points.end(),
+                        correct_points.begin()
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A cell_segment2")
+    {
+        const rl::cell_segment2 segment(1, 1, 4, 2);
+        WHEN("The cell_segment2 is walked over")
+        {
+            rl::walk<int>(
+                segment,
+                [&](const rl::cell_vector2<int>& step)
+                {
+                    traversed_points.push_back(step);
+                }
+            );
+            THEN("The walked over points are correct")
+            {
+                std::vector<rl::cell_vector2<int>> correct_points =
+                    {
+                        rl::cell_vector2(1, 1),
+                        rl::cell_vector2(2, 1),
+                        rl::cell_vector2(3, 2),
+                        rl::cell_vector2(4, 2)
+                    };
+                CHECK(
+                    std::equal(
+                        traversed_points.begin(),
+                        traversed_points.end(),
+                        correct_points.begin()
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A cell_box2")
+    {
+        const rl::cell_box2 box(1, 1, 3, 3);
+        WHEN("The cell_box2 is walked over")
+        {
+            rl::walk<int>(
+                box,
+                [&](const rl::cell_vector2<int>& step)
+                {
+                    traversed_points.push_back(step);
+                }
+            );
+            THEN("The walked over points are correct")
+            {
+                std::vector<rl::cell_vector2<int>> correct_points =
+                    {
+                        rl::cell_vector2(1, 1),
+                        rl::cell_vector2(2, 1),
+                        rl::cell_vector2(3, 1),
+                        rl::cell_vector2(1, 2),
+                        rl::cell_vector2(2, 2),
+                        rl::cell_vector2(3, 2),
+                        rl::cell_vector2(1, 3),
+                        rl::cell_vector2(2, 3),
+                        rl::cell_vector2(3, 3)
+                    };
+                CHECK(
+                    std::equal(
+                        traversed_points.begin(),
+                        traversed_points.end(),
+                        correct_points.begin()
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A cell_circle2")
+    {
+        const rl::cell_circle2 circle(3, 3, 2.0f);
+        WHEN("The cell_circle2 is walked over")
+        {
+            rl::walk<int>(
+                circle,
+                [&](const rl::cell_vector2<int>& step)
+                {
+                    traversed_points.push_back(step);
+                }
+            );
+            THEN("The walked over points are correct")
+            {
+                std::vector<rl::cell_vector2<int>> correct_points =
+                    {
+                        rl::cell_vector2(2, 2),
+                        rl::cell_vector2(2, 4),
+                        rl::cell_vector2(3, 2),
+                        rl::cell_vector2(3, 4),
+                        rl::cell_vector2(4, 2),
+                        rl::cell_vector2(4, 4),
+                        rl::cell_vector2(3, 1),
+                        rl::cell_vector2(3, 5),
+                        rl::cell_vector2(1, 3),
+                        rl::cell_vector2(2, 3),
+                        rl::cell_vector2(3, 3),
+                        rl::cell_vector2(4, 3),
+                        rl::cell_vector2(5, 3)
+                    };
+                CHECK(
+                    std::equal(
+                        traversed_points.begin(),
+                        traversed_points.end(),
+                        correct_points.begin()
+                    )
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add functions for walking over all cells of a cell shape. This is useful for drawing shapes to a terminal.
