### PR TITLE
Colors

### DIFF
--- a/include/rlm/color/color_channel.hpp
+++ b/include/rlm/color/color_channel.hpp
@@ -30,10 +30,10 @@ namespace rl
     constexpr Ca color_channel_cast(Cb channel) noexcept;
 
     template<rl::color_channel C>
-    constexpr C color_channel_max_value();
+    constexpr C color_channel_max_value() noexcept;
 
     template<rl::color_channel C>
-    constexpr C color_channel_clamp(C channel);
+    constexpr C color_channel_clamp(C channel) noexcept;
 }
 
 #include <rlm/color/detail/color_channel.inl>

--- a/include/rlm/color/color_channel.hpp
+++ b/include/rlm/color/color_channel.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel Ca, rl::color_channel Cb>
+    constexpr Ca color_channel_cast(Cb channel) noexcept;
+
+    template<rl::color_channel C>
+    constexpr C color_channel_max_value();
+
+    template<rl::color_channel C>
+    constexpr C color_channel_clamp(C channel);
+}
+
+#include <rlm/color/detail/color_channel.inl>

--- a/include/rlm/color/color_channel.hpp
+++ b/include/rlm/color/color_channel.hpp
@@ -1,3 +1,25 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #pragma once
 
 #include <rlm/color/concepts.hpp>

--- a/include/rlm/color/color_conversion.hpp
+++ b/include/rlm/color/color_conversion.hpp
@@ -1,0 +1,1 @@
+#pragma once

--- a/include/rlm/color/color_conversion.hpp
+++ b/include/rlm/color/color_conversion.hpp
@@ -1,1 +1,87 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
 #pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    struct color_g;
+    template<rl::color_channel C>
+    struct color_ga;
+    template<rl::color_channel C>
+    struct color_rgb;
+    template<rl::color_channel C>
+    struct color_rgba;
+
+    template<rl::color_channel C>
+    constexpr rl::color_g<Ca> to_color_g(rl::color_g<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_g<Ca> to_color_g(rl::color_rgb<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_ga<Ca> to_color_ga(rl::color_ga<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgb<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_g<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_g<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept; 
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept;
+
+    template<rl::color_channel C>
+    constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgba<Cb> color) noexcept;
+}
+
+#include <rlm/color/detail/color_conversion.inl>

--- a/include/rlm/color/color_conversion.hpp
+++ b/include/rlm/color/color_conversion.hpp
@@ -35,52 +35,52 @@ namespace rl
     template<rl::color_channel C>
     struct color_rgba;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_g<Ca> to_color_g(rl::color_g<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_g<Ca> to_color_g(rl::color_rgb<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_ga<Ca> to_color_ga(rl::color_ga<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgb<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_g<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_g<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept; 
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept;
 
-    template<rl::color_channel C>
+    template<rl::color_channel Ca, rl::color_channel Cb>
     constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgba<Cb> color) noexcept;
 }
 

--- a/include/rlm/color/color_g.hpp
+++ b/include/rlm/color/color_g.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    struct color_g
+    {
+        C g = 0;
+
+        constexpr color_g() noexcept = default;
+        constexpr color_g(C g) noexcept;
+    };
+}

--- a/include/rlm/color/color_g.hpp
+++ b/include/rlm/color/color_g.hpp
@@ -33,5 +33,11 @@ namespace rl
 
         constexpr color_g() noexcept = default;
         constexpr color_g(C g) noexcept;
+
+        constexpr bool operator==(const rl::color_g<C>& that) const noexcept;
+
+        constexpr bool operator!=(const rl::color_g<C>& that) const noexcept;
     };
 }
+
+#include <rlm/color/detail/color_g.inl>

--- a/include/rlm/color/color_ga.hpp
+++ b/include/rlm/color/color_ga.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    struct color_ga
+    {
+        C g = 0;
+        C a = 0;
+
+        constexpr color_ga() noexcept = default;
+        constepxr color_ga(C g, C a) noexcept;
+    };
+}

--- a/include/rlm/color/color_ga.hpp
+++ b/include/rlm/color/color_ga.hpp
@@ -33,6 +33,6 @@ namespace rl
         C a = 0;
 
         constexpr color_ga() noexcept = default;
-        constepxr color_ga(C g, C a) noexcept;
+        constexpr color_ga(C g, C a) noexcept;
     };
 }

--- a/include/rlm/color/color_rgb.hpp
+++ b/include/rlm/color/color_rgb.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    struct color_rgb
+    {
+        C r = 0;
+        C g = 0;
+        C b = 0;
+
+        constexpr color_rgb() noexcept = default;
+        constexpr color_rgb(C r, C g, C b) noexcept;
+    };
+}

--- a/include/rlm/color/color_rgb.hpp
+++ b/include/rlm/color/color_rgb.hpp
@@ -35,5 +35,11 @@ namespace rl
 
         constexpr color_rgb() noexcept = default;
         constexpr color_rgb(C r, C g, C b) noexcept;
+
+        constexpr bool operator==(const rl::color_rgb<C>& that) const noexcept;
+
+        constexpr bool operator!=(const rl::color_rgb<C>& that) const noexcept;
     };
 }
+
+#include <rlm/color/detail/color_rgb.inl>

--- a/include/rlm/color/color_rgba.hpp
+++ b/include/rlm/color/color_rgba.hpp
@@ -36,5 +36,11 @@ namespace rl
 
         constexpr color_rgba() noexcept = default;
         constexpr color_rgba(C r, C g, C b, C a) noexcept;
+
+        constexpr bool operator==(const rl::color_rgba<C>& that) const noexcept;
+
+        constexpr bool operator!=(const rl::color_rgba<C>& that) const noexcept;
     };
 }
+
+#include <rlm/color/detail/color_rgba.inl>

--- a/include/rlm/color/color_rgba.hpp
+++ b/include/rlm/color/color_rgba.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    struct color_rgba
+    {
+        C r = 0;
+        C g = 0;
+        C b = 0;
+        C a = 0;
+
+        constexpr color_rgba() noexcept = default;
+        constexpr color_rgba(C r, C g, C b, C a) noexcept;
+    };
+}

--- a/include/rlm/color/concepts.hpp
+++ b/include/rlm/color/concepts.hpp
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/concepts.hpp>
+
+namespace rl
+{
+    template<typename T>
+    concept color_channel = rl::floating_point<T> || rl::unsigned_integral<T>;
+}

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -73,12 +73,19 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
             Ca,
             Cb
         >::type;
-        return
-            static_cast<Ca>(
-                static_cast<LargestType>(std::numeric_limits<LargestType>::max()) /
-                static_cast<LargestType>(std::numeric_limits<SmallestType>::max()) *
-                static_cast<LargestType>(channel)
-            );
+        if constexpr (std::is_same<Cb, SmallestType>::value)
+        {
+            return
+                static_cast<Ca>(
+                    static_cast<LargestType>(std::numeric_limits<LargestType>::max()) /
+                    static_cast<LargestType>(std::numeric_limits<SmallestType>::max()) *
+                    static_cast<LargestType>(channel)
+                );
+        }
+        else
+        {
+
+        }
     }
     else if constexpr (
         std::is_floating_point<Ca>::value &&

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -44,7 +44,7 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
                     static_cast<Cb>(
                         rl::color_channel_max_value<Cb>()
                     )
-                );
+                )
             );
     }
     else if constexpr (

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -63,11 +63,11 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
         std::is_unsigned<Cb>::value
     )
     {
-        using LargestType = std::conditional_v<
-            sizeof(Ca) > sizeof(Cb),
+        using LargestType = std::conditional<
+            (sizeof(Ca) > sizeof(Cb)),
             Ca,
             Cb
-        >;
+        >::type;
         return
             static_cast<Ca>(
                 static_cast<LargestType>(std::numeric_limits<Ca>::max()) /

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -82,9 +82,13 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
                     static_cast<LargestType>(channel)
                 );
         }
-        else
+        else if constexpr (std::is_same<Cb, LargestType>::value)
         {
-
+            return
+                static_cast<Ca>(
+                    static_cast<LargestType>(channel) /
+                    static_cast<LargestType>(std::numeric_limits<SmallestType>::max())
+                );
         }
     }
     else if constexpr (

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -82,6 +82,7 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
         return static_cast<Ca>(channel);
     }
     static_assert("invalid color channel type");
+    return channel;
 }
 
 template<rl::color_channel C>
@@ -96,6 +97,7 @@ constexpr C rl::color_channel_max_value()
         return std::numeric_limits<C>::max();
     }
     static_assert(true, "invalid color channel type");
+    return 0;
 }
 
 template<rl::color_channel C>
@@ -110,5 +112,5 @@ constexpr C rl::color_channel_clamp(C channel)
                 rl::color_channel_max_value<C>()
             );
     }
-    static_assert(true, "invalid color channel type");
+    return channel;
 }

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -68,10 +68,15 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
             Ca,
             Cb
         >::type;
+        using SmallestType = std::conditional<
+            (sizeof(Ca) < sizeof(Cb)),
+            Ca,
+            Cb
+        >::type;
         return
             static_cast<Ca>(
-                static_cast<LargestType>(std::numeric_limits<Ca>::max()) /
-                static_cast<LargestType>(std::numeric_limits<Cb>::max()) *
+                static_cast<LargestType>(std::numeric_limits<LargestType>::max()) /
+                static_cast<LargestType>(std::numeric_limits<SmallestType>::max()) *
                 static_cast<LargestType>(channel)
             );
     }

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -105,7 +105,7 @@ constexpr C rl::color_channel_max_value() noexcept
     {
         return static_cast<C>(1);
     }
-    else //if constexpr (std::is_unsigned<C>::value)
+    else if constexpr (std::is_unsigned<C>::value)
     {
         return std::numeric_limits<C>::max();
     }

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <rlm/color/concepts.hpp>
+#include <rlm/clamp.hpp>
 #include <type_traits>
 
 template<rl::color_channel Ca, rl::color_channel Cb>

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -29,7 +29,11 @@
 template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr Ca rl::color_channel_cast(Cb channel) noexcept
 {
-   if constexpr (
+    if constexpr (std::is_same<Ca, Cb>::value)
+    {
+        return rl::color_channel_clamp<Cb>(channel);
+    }
+    else if constexpr (
         std::is_floating_point<Ca>::value &&
         std::is_unsigned<Cb>::value
     )

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -63,12 +63,12 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
         std::is_unsigned<Cb>::value
     )
     {
-        using LargestType = std::conditional<
+        using LargestType = typename std::conditional<
             (sizeof(Ca) > sizeof(Cb)),
             Ca,
             Cb
         >::type;
-        using SmallestType = std::conditional<
+        using SmallestType = typename std::conditional<
             (sizeof(Ca) < sizeof(Cb)),
             Ca,
             Cb

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -99,10 +99,14 @@ constexpr C rl::color_channel_max_value()
 template<rl::color_channel C>
 constexpr C rl::color_channel_clamp(C channel)
 {
-    return
-        rl::clamp<C>(
-            channel,
-            static_cast<C>(0),
-            rl::color_channel_max_value<C>()
-        );
+    if constexpr (std::is_floating_point<C>::value)
+    {
+        return
+            rl::clamp<C>(
+                channel,
+                static_cast<C>(0),
+                rl::color_channel_max_value<C>()
+            );
+    }
+    return channel;
 }

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -81,6 +81,7 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
     {
         return static_cast<Ca>(channel);
     }
+    static_assert("invalid color channel type");
 }
 
 template<rl::color_channel C>
@@ -94,6 +95,7 @@ constexpr C rl::color_channel_max_value()
     {
         return std::numeric_limits<C>::max();
     }
+    static_assert(true, "invalid color channel type");
 }
 
 template<rl::color_channel C>
@@ -108,5 +110,5 @@ constexpr C rl::color_channel_clamp(C channel)
                 rl::color_channel_max_value<C>()
             );
     }
-    return channel;
+    static_assert(true, "invalid color channel type");
 }

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+#include <type_traits>
+
+template<rl::color_channel Ca, rl::color_channel Cb>
+constexpr Ca rl::color_channel_cast(Cb channel) noexcept
+{
+   if constexpr (
+        std::is_floating_point<Ca>::value &&
+        std::is_unsigned<Cb>::value
+    )
+    {
+        return
+            static_cast<Ca>(
+                rl::clamp<Cb>(
+                    channel *
+                    static_cast<Ca>(
+                        rl::color_channel_max_value<Cb>()
+                    ),
+                    static_cast<Cb>(0),
+                    static_cast<Cb>(
+                        rl::color_channel_max_value<Cb>()
+                    )
+                );
+            );
+    }
+    else if constexpr (
+        std::is_unsigned<Ca>::value &&
+        std::is_floating_point<Cb>::value
+    )
+    {
+        return
+            static_cast<Ca>(1) /
+            static_cast<Ca>(rl::color_channel_max_value<Cb>()) *
+            static_cast<Ca>(channel);
+    }
+    else if constexpr (
+        std::is_unsigned<Ca>::value &&
+        std::is_unsigned<Cb>::value
+    )
+    {
+        using LargestType = std::conditional_v<
+            sizeof(Ca) > sizeof(Cb),
+            Ca,
+            Cb
+        >;
+        return
+            static_cast<Ca>(
+                static_cast<LargestType>(std::numeric_limits<Ca>::max()) /
+                static_cast<LargestType>(std::numeric_limits<Cb>::max()) *
+                static_cast<LargestType>(channel)
+            );
+    }
+    else if constexpr (
+        std::is_floating_point<Ca>::value &&
+        std::is_floating_point<Cb>::value  
+    )
+    {
+        return static_cast<Ca>(channel);
+    }
+}
+
+template<rl::color_channel C>
+constexpr C rl::color_channel_max_value()
+{
+    if constexpr (std::is_floating_point<C>::value)
+    {
+        return static_cast<C>(1);
+    }
+    else //if constexpr (std::is_unsigned<C>::value)
+    {
+        return std::numeric_limits<C>::max();
+    }
+}
+
+template<rl::color_channel C>
+constexpr C rl::color_channel_clamp(C channel)
+{
+    return
+        rl::clamp<C>(
+            channel,
+            static_cast<C>(0),
+            rl::color_channel_max_value<C>()
+        );
+}

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -87,7 +87,7 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
 }
 
 template<rl::color_channel C>
-constexpr C rl::color_channel_max_value()
+constexpr C rl::color_channel_max_value() noexcept
 {
     if constexpr (std::is_floating_point<C>::value)
     {
@@ -102,7 +102,7 @@ constexpr C rl::color_channel_max_value()
 }
 
 template<rl::color_channel C>
-constexpr C rl::color_channel_clamp(C channel)
+constexpr C rl::color_channel_clamp(C channel) noexcept
 {
     if constexpr (std::is_floating_point<C>::value)
     {

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -35,18 +35,11 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
     )
     {
         return
+            rl::color_channel_max_value<Ca>() /
             static_cast<Ca>(
-                rl::clamp<Cb>(
-                    channel *
-                    static_cast<Ca>(
-                        rl::color_channel_max_value<Cb>()
-                    ),
-                    static_cast<Cb>(0),
-                    static_cast<Cb>(
-                        rl::color_channel_max_value<Cb>()
-                    )
-                )
-            );
+                rl::color_channel_max_value<Cb>() 
+            ) *
+            static_cast<Ca>(channel);
     }
     else if constexpr (
         std::is_unsigned<Ca>::value &&
@@ -54,9 +47,12 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
     )
     {
         return
-            static_cast<Ca>(1) /
-            static_cast<Ca>(rl::color_channel_max_value<Cb>()) *
-            static_cast<Ca>(channel);
+            static_cast<Ca>(
+                rl::color_channel_clamp<Cb>(channel) *
+                static_cast<Ca>(
+                    rl::color_channel_max_value<Ca>()
+                )
+            );
     }
     else if constexpr (
         std::is_unsigned<Ca>::value &&

--- a/include/rlm/color/detail/color_channel.inl
+++ b/include/rlm/color/detail/color_channel.inl
@@ -78,7 +78,7 @@ constexpr Ca rl::color_channel_cast(Cb channel) noexcept
     {
         return static_cast<Ca>(channel);
     }
-    static_assert("invalid color channel type");
+    static_assert(true, "invalid color channel type");
     return channel;
 }
 

--- a/include/rlm/color/detail/color_conversion.inl
+++ b/include/rlm/color/detail/color_conversion.inl
@@ -47,7 +47,7 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_g<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept
+constexpr rl::color_g<Ca> rl::to_color_g(rl::color_ga<Cb> color) noexcept
 {
     return
         rl::color_g<Ca>(
@@ -73,7 +73,7 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgb<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept
+constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgba<Cb> color) noexcept
 {
     return
         rl::color_g<Ca>(
@@ -88,7 +88,7 @@ constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept
+constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_g<Cb> color) noexcept
 {
     return
         rl::color_ga<Ca>(
@@ -130,7 +130,7 @@ constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgb<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept
+constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgba<Cb> color) noexcept
 {
     return
         rl::color_ga<Ca>(
@@ -165,7 +165,7 @@ constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_g<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept
+constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_ga<Cb> color) noexcept
 {
     return
         rl::color_rgb<Ca>(
@@ -182,7 +182,7 @@ constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept
+constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_rgb<Cb> color) noexcept
 {
     return
         rl::color_rgb<Ca>(
@@ -199,7 +199,7 @@ constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept
+constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_rgba<Cb> color) noexcept
 {
     return
         rl::color_rgb<Ca>(
@@ -234,7 +234,7 @@ constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_g<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept
+constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_ga<Cb> color) noexcept
 {
     return
         rl::color_rgba<Ca>(
@@ -254,7 +254,7 @@ constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept
+constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_rgb<Cb> color) noexcept
 {
     return
         rl::color_rgba<Ca>(
@@ -272,7 +272,7 @@ constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept
 }
 
 template<rl::color_channel Ca, rl::color_channel Cb>
-constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgba<Cb> color) noexcept
+constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_rgba<Cb> color) noexcept
 {
     return
         rl::color_rgba<Ca>(

--- a/include/rlm/color/detail/color_conversion.inl
+++ b/include/rlm/color/detail/color_conversion.inl
@@ -33,7 +33,7 @@
 #include <limits>
 #include <cstdint>
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_g<Ca> rl::to_color_g(rl::color_g<Cb> color) noexcept
 {
     return
@@ -46,7 +46,7 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_g<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept
 {
     return
@@ -57,7 +57,7 @@ constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgb<Cb> color) noexcept
 {
     return
@@ -72,7 +72,7 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgb<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept
 {
     return
@@ -87,7 +87,7 @@ constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept
 {
     return
@@ -99,7 +99,7 @@ constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_ga<Cb> color) noexcept
 {
     return
@@ -113,7 +113,7 @@ constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_ga<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgb<Cb> color) noexcept
 {
     return
@@ -129,7 +129,7 @@ constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgb<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept
 {
     return
@@ -147,7 +147,7 @@ constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_g<Cb> color) noexcept
 {
     return
@@ -162,7 +162,7 @@ constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_g<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept
 {
     return
@@ -179,7 +179,7 @@ constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept
 {
     return
@@ -196,7 +196,7 @@ constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept
 {
     return
@@ -213,7 +213,7 @@ constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_g<Cb> color) noexcept
 {
     return
@@ -231,7 +231,7 @@ constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_g<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept
 {
     return
@@ -251,7 +251,7 @@ constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept
 {
     return
@@ -269,7 +269,7 @@ constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept
         );
 }
 
-template<rl::color_channel C>
+template<rl::color_channel Ca, rl::color_channel Cb>
 constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgba<Cb> color) noexcept
 {
     return

--- a/include/rlm/color/detail/color_conversion.inl
+++ b/include/rlm/color/detail/color_conversion.inl
@@ -64,9 +64,9 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgb<Cb> color) noexcept
         rl::color_g<Ca>(
             rl::color_channel_cast<Ca, Cb>(
                 rl::rgb_to_grayscale_libpng<Cb>(
-                    color.r,
-                    color.g,
-                    color.b
+                    rl::color_channel_clamp(color.r),
+                    rl::color_channel_clamp(color.g),
+                    rl::color_channel_clamp(color.b)
                 )
             )
         );
@@ -79,9 +79,9 @@ constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgba<Cb> color) noexcept
         rl::color_g<Ca>(
             rl::color_channel_cast<Ca, Cb>(
                 rl::rgb_to_grayscale_libpng<Cb>(
-                    color.r,
-                    color.g,
-                    color.b
+                    rl::color_channel_clamp(color.r),
+                    rl::color_channel_clamp(color.g),
+                    rl::color_channel_clamp(color.b)
                 )
             )
         );
@@ -120,9 +120,9 @@ constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgb<Cb> color) noexcept
         rl::color_ga<Ca>(
             rl::color_channel_cast<Ca, Cb>(
                 rl::rgb_to_grayscale_libpng<Cb>(
-                    color.r,
-                    color.g,
-                    color.b
+                    rl::color_channel_clamp(color.r),
+                    rl::color_channel_clamp(color.g),
+                    rl::color_channel_clamp(color.b)
                 )
             ),
             rl::color_channel_max_value<Ca>()

--- a/include/rlm/color/detail/color_conversion.inl
+++ b/include/rlm/color/detail/color_conversion.inl
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+#include <rlm/color/color_channel.hpp>
+#include <rlm/color/grayscale_conversion.hpp>
+#include <rlm/color/color_g.hpp>
+#include <rlm/color/color_ga.hpp>
+#include <rlm/color/color_rgb.hpp>
+#include <rlm/color/color_rgba.hpp>
+#include <type_traits>
+#include <limits>
+#include <cstdint>
+
+template<rl::color_channel C>
+constexpr rl::color_g<Ca> rl::to_color_g(rl::color_g<Cb> color) noexcept
+{
+    return
+        rl::color_g<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(
+                    color.g
+                )
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_g<Ca> to_color_g(rl::color_ga<Cb> color) noexcept
+{
+    return
+        rl::color_g<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_g<Ca> rl::to_color_g(rl::color_rgb<Cb> color) noexcept
+{
+    return
+        rl::color_g<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::rgb_to_grayscale_libpng<Cb>(
+                    color.r,
+                    color.g,
+                    color.b
+                )
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_g<Ca> to_color_g(rl::color_rgba<Cb> color) noexcept
+{
+    return
+        rl::color_g<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::rgb_to_grayscale_libpng<Cb>(
+                    color.r,
+                    color.g,
+                    color.b
+                )
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_ga<Ca> to_color_ga(rl::color_g<Cb> color) noexcept
+{
+    return
+        rl::color_ga<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_max_value<Ca>()
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_ga<Cb> color) noexcept
+{
+    return
+        rl::color_ga<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.a)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_ga<Ca> rl::to_color_ga(rl::color_rgb<Cb> color) noexcept
+{
+    return
+        rl::color_ga<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::rgb_to_grayscale_libpng<Cb>(
+                    color.r,
+                    color.g,
+                    color.b
+                )
+            ),
+            rl::color_channel_max_value<Ca>()
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_ga<Ca> to_color_ga(rl::color_rgba<Cb> color) noexcept
+{
+    return
+        rl::color_ga<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::rgb_to_grayscale_libpng<Cb>(
+                    color.r,
+                    color.g,
+                    color.b
+                )
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.a)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_g<Cb> color) noexcept
+{
+    return
+        rl::color_rgb<Ca>(
+            rl::color_::max()()channel_cast<Ca, Cb>(color.g),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_ga<Cb> color) noexcept
+{
+    return
+        rl::color_rgb<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgb<Cb> color) noexcept
+{
+    return
+        rl::color_rgb<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.r)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.b)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgb<Ca> to_color_rgb(rl::color_rgba<Cb> color) noexcept
+{
+    return
+        rl::color_rgb<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.r)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.b)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgba<Ca> rl::to_color_rgba(rl::color_g<Cb> color) noexcept
+{
+    return
+        rl::color_rgba<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_max_value<Ca>()
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_ga<Cb> color) noexcept
+{
+    return
+        rl::color_rgba<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.a)
+            )
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgb<Cb> color) noexcept
+{
+    return
+        rl::color_rgba<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.r)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.b)
+            ),
+            rl::color_channel_max_value<Ca>()
+        );
+}
+
+template<rl::color_channel C>
+constexpr rl::color_rgba<Ca> to_color_rgba(rl::color_rgba<Cb> color) noexcept
+{
+    return
+        rl::color_rgba<Ca>(
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.r)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.b)
+            ),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.a)
+            )
+        );
+}

--- a/include/rlm/color/detail/color_conversion.inl
+++ b/include/rlm/color/detail/color_conversion.inl
@@ -152,7 +152,9 @@ constexpr rl::color_rgb<Ca> rl::to_color_rgb(rl::color_g<Cb> color) noexcept
 {
     return
         rl::color_rgb<Ca>(
-            rl::color_::max()()channel_cast<Ca, Cb>(color.g),
+            rl::color_channel_cast<Ca, Cb>(
+                rl::color_channel_clamp<Cb>(color.g)
+            ),
             rl::color_channel_cast<Ca, Cb>(
                 rl::color_channel_clamp<Cb>(color.g)
             ),

--- a/include/rlm/color/detail/color_g.inl
+++ b/include/rlm/color/detail/color_g.inl
@@ -24,21 +24,22 @@
 
 #include <rlm/color/concepts.hpp>
 
-namespace rl
+template<rl::color_channel C>
+constexpr rl::color_g<C>::color_g(C g) noexcept
+    : g(g)
 {
-    template<rl::color_channel C>
-    struct color_ga
-    {
-        C g = 0;
-        C a = 0;
-
-        constexpr color_ga() noexcept = default;
-        constexpr color_ga(C g, C a) noexcept;
-
-        constexpr bool operator==(const rl::color_ga<C>& that) const noexcept;
-
-        constexpr bool operator!=(const rl::color_ga<C>& that) const noexcept;
-    };
 }
 
-#include <rlm/color/detail/color_ga.inl>
+template<rl::color_channel C>
+constexpr bool rl::color_g<C>::operator==(const rl::color_g<C>& that) const noexcept
+{
+    return
+        this->g == that.g;
+}
+
+template<rl::color_channel C>
+constexpr bool rl::color_g<C>::operator!=(const rl::color_g<C>& that) const noexcept
+{
+    return
+        this->g != that.g;
+}

--- a/include/rlm/color/detail/color_ga.inl
+++ b/include/rlm/color/detail/color_ga.inl
@@ -25,7 +25,7 @@
 #include <rlm/color/concepts.hpp>
 
 template<rl::color_channel C>
-constexpr rl::color_ga<C>::color_g(C g, C a) noexcept
+constexpr rl::color_ga<C>::color_ga(C g, C a) noexcept
     : g(g)
     , a(a)
 {

--- a/include/rlm/color/detail/color_ga.inl
+++ b/include/rlm/color/detail/color_ga.inl
@@ -24,21 +24,25 @@
 
 #include <rlm/color/concepts.hpp>
 
-namespace rl
+template<rl::color_channel C>
+constexpr rl::color_ga<C>::color_g(C g, C a) noexcept
+    : g(g)
+    , a(a)
 {
-    template<rl::color_channel C>
-    struct color_ga
-    {
-        C g = 0;
-        C a = 0;
-
-        constexpr color_ga() noexcept = default;
-        constexpr color_ga(C g, C a) noexcept;
-
-        constexpr bool operator==(const rl::color_ga<C>& that) const noexcept;
-
-        constexpr bool operator!=(const rl::color_ga<C>& that) const noexcept;
-    };
 }
 
-#include <rlm/color/detail/color_ga.inl>
+template<rl::color_channel C>
+constexpr bool rl::color_ga<C>::operator==(const rl::color_ga<C>& that) const noexcept
+{
+    return
+        this->g == that.g &&
+        this->a == that.a;
+}
+
+template<rl::color_channel C>
+constexpr bool rl::color_ga<C>::operator!=(const rl::color_ga<C>& that) const noexcept
+{
+    return
+        this->g != that.g &&
+        this->a != that.a;
+}

--- a/include/rlm/color/detail/color_rgb.inl
+++ b/include/rlm/color/detail/color_rgb.inl
@@ -24,21 +24,28 @@
 
 #include <rlm/color/concepts.hpp>
 
-namespace rl
+template<rl::color_channel C>
+constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b) noexcept
+    : r(g)
+    , g(a)
+    , b(b)
 {
-    template<rl::color_channel C>
-    struct color_ga
-    {
-        C g = 0;
-        C a = 0;
-
-        constexpr color_ga() noexcept = default;
-        constexpr color_ga(C g, C a) noexcept;
-
-        constexpr bool operator==(const rl::color_ga<C>& that) const noexcept;
-
-        constexpr bool operator!=(const rl::color_ga<C>& that) const noexcept;
-    };
 }
 
-#include <rlm/color/detail/color_ga.inl>
+template<rl::color_channel C>
+constexpr bool rl::color_rgb<C>::operator==(const rl::color_rgb<C>& that) const noexcept
+{
+    return
+        this->r == that.r &&
+        this->g == that.g &&
+        this->b == that.b;
+}
+
+template<rl::color_channel C>
+constexpr bool rl::color_rgba<C>::operator!=(const rl::color_rgba<C>& that) const noexcept
+{
+    return
+        this->r != that.r &&
+        this->g != that.g &&
+        this->b != that.b;
+}

--- a/include/rlm/color/detail/color_rgb.inl
+++ b/include/rlm/color/detail/color_rgb.inl
@@ -26,7 +26,7 @@
 
 template<rl::color_channel C>
 constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b) noexcept
-    : r(g)
+    : r(r)
     , g(g)
     , b(b)
 {

--- a/include/rlm/color/detail/color_rgb.inl
+++ b/include/rlm/color/detail/color_rgb.inl
@@ -27,7 +27,7 @@
 template<rl::color_channel C>
 constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b) noexcept
     : r(g)
-    , g(a)
+    , g(g)
     , b(b)
 {
 }
@@ -42,7 +42,7 @@ constexpr bool rl::color_rgb<C>::operator==(const rl::color_rgb<C>& that) const 
 }
 
 template<rl::color_channel C>
-constexpr bool rl::color_rgba<C>::operator!=(const rl::color_rgba<C>& that) const noexcept
+constexpr bool rl::color_rgb<C>::operator!=(const rl::color_rgb<C>& that) const noexcept
 {
     return
         this->r != that.r &&

--- a/include/rlm/color/detail/color_rgba.inl
+++ b/include/rlm/color/detail/color_rgba.inl
@@ -26,8 +26,8 @@
 
 template<rl::color_channel C>
 constexpr rl::color_rgba<C>::color_rgba(C r, C g, C b, C a) noexcept
-    : r(g)
-    , g(a)
+    : r(r)
+    , g(g)
     , b(b)
     , a(a)
 {

--- a/include/rlm/color/detail/color_rgba.inl
+++ b/include/rlm/color/detail/color_rgba.inl
@@ -24,21 +24,31 @@
 
 #include <rlm/color/concepts.hpp>
 
-namespace rl
+template<rl::color_channel C>
+constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b, C a) noexcept
+    : r(g)
+    , g(a)
+    , b(b)
+    , a(a)
 {
-    template<rl::color_channel C>
-    struct color_ga
-    {
-        C g = 0;
-        C a = 0;
-
-        constexpr color_ga() noexcept = default;
-        constexpr color_ga(C g, C a) noexcept;
-
-        constexpr bool operator==(const rl::color_ga<C>& that) const noexcept;
-
-        constexpr bool operator!=(const rl::color_ga<C>& that) const noexcept;
-    };
 }
 
-#include <rlm/color/detail/color_ga.inl>
+template<rl::color_channel C>
+constexpr bool rl::color_rgb<C>::operator==(const rl::color_rgb<C>& that) const noexcept
+{
+    return
+        this->r == that.r &&
+        this->g == that.g &&
+        this->b == that.b &&
+        this->a == that.a;
+}
+
+template<rl::color_channel C>
+constexpr bool rl::color_rgba<C>::operator!=(const rl::color_rgba<C>& that) const noexcept
+{
+    return
+        this->r != that.r &&
+        this->g != that.g &&
+        this->b != that.b &&
+        this->a != that.a;
+}

--- a/include/rlm/color/detail/color_rgba.inl
+++ b/include/rlm/color/detail/color_rgba.inl
@@ -25,7 +25,7 @@
 #include <rlm/color/concepts.hpp>
 
 template<rl::color_channel C>
-constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b, C a) noexcept
+constexpr rl::color_rgba<C>::color_rgba(C r, C g, C b, C a) noexcept
     : r(g)
     , g(a)
     , b(b)
@@ -34,7 +34,7 @@ constexpr rl::color_rgb<C>::color_rgb(C r, C g, C b, C a) noexcept
 }
 
 template<rl::color_channel C>
-constexpr bool rl::color_rgb<C>::operator==(const rl::color_rgb<C>& that) const noexcept
+constexpr bool rl::color_rgba<C>::operator==(const rl::color_rgba<C>& that) const noexcept
 {
     return
         this->r == that.r &&

--- a/include/rlm/color/detail/grayscale_conversion.inl
+++ b/include/rlm/color/detail/grayscale_conversion.inl
@@ -24,6 +24,7 @@
 
 #include <rlm/color/concepts.hpp>
 #include <rlm/color/color_channel.hpp>
+#include <cstdint>
 #include <type_traits>
 
 template<rl::color_channel C>
@@ -41,12 +42,19 @@ constexpr C rl::rgb_to_grayscale_libpng(C r, C g, C b) noexcept
     }
     else // if constexpr (std::is_unsigned<C>::value)
     {
+        static_assert(
+            !std::is_same<C, std::uintmax_t>::value,
+            "color channel type unconvertable to grayscale"
+        );
         return 
-            static_cast<C>(0.21268) *
-            r +
-            static_cast<C>(0.7151) *
-            g +
-            static_cast<C>(0.07217) *
-            b;
+            (
+                static_cast<std::uintmax_t>(6969) *
+                static_cast<std::uintmax_t>(r) +
+                static_cast<std::uintmax_t>(23434) *
+                static_cast<std::uintmax_t>(g) +
+                static_cast<std::uintmax_t>(2365) *
+                static_cast<std::uintmax_t>(b)
+            ) /
+            static_cast<std::uintmax_t>(32768);
     }
 }

--- a/include/rlm/color/detail/grayscale_conversion.inl
+++ b/include/rlm/color/detail/grayscale_conversion.inl
@@ -29,7 +29,7 @@
 template<rl::color_channel C>
 constexpr C rl::rgb_to_grayscale_libpng(C r, C g, C b) noexcept
 {
-    if constexpr (rl::is_floating_point<C>::value)
+    if constexpr (std::is_floating_point<C>::value)
     {
         return 
             static_cast<C>(0.21268) *
@@ -39,7 +39,7 @@ constexpr C rl::rgb_to_grayscale_libpng(C r, C g, C b) noexcept
             static_cast<C>(0.07217) *
             rl::color_channel_clamp<C>(b);
     }
-    else // if constexpr (rl::is_unsigned<C>::value)
+    else // if constexpr (std::is_unsigned<C>::value)
     {
         return 
             static_cast<C>(0.21268) *

--- a/include/rlm/color/detail/grayscale_conversion.inl
+++ b/include/rlm/color/detail/grayscale_conversion.inl
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+#include <rlm/color/color_channel.hpp>
+#include <type_traits>
+
+template<rl::color_channel C>
+constexpr C rl::rgb_to_grayscale_libpng(C r, C g, C b) noexcept
+{
+    if constexpr (rl::is_floating_point<C>::value)
+    {
+        return 
+            static_cast<C>(0.21268) *
+            rl::color_channel_clamp<C>(r) +
+            static_cast<C>(0.7151) *
+            rl::color_channel_clamp<C>(g) +
+            static_cast<C>(0.07217) *
+            rl::color_channel_clamp<C>(b);
+    }
+    else // if constexpr (rl::is_unsigned<C>::value)
+    {
+        return 
+            static_cast<C>(0.21268) *
+            r +
+            static_cast<C>(0.7151) *
+            g +
+            static_cast<C>(0.07217) *
+            b;
+    }
+}

--- a/include/rlm/color/detail/ostream.inl
+++ b/include/rlm/color/detail/ostream.inl
@@ -20,53 +20,42 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <catch2/catch_all.hpp>
+#pragma once
+
+#include <ostream>
+#include <rlm/color/concepts.hpp>
+#include <rlm/color/color_g.hpp>
 #include <rlm/color/color_ga.hpp>
-#include <rlm/color/ostream.hpp>
-#include <cstdint>
+#include <rlm/color/color_rgb.hpp>
+#include <rlm/color/color_rgba.hpp>
 
-SCENARIO("A color_ga is constructed")
+namespace rl
 {
-    GIVEN("A color_ga constructed with its default constructor")
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_g<C>& color)
     {
-        rl::color_ga<std::uint8_t> color;
-        THEN("All properties are correct")
-        {
-            CHECK(color.g == 0);
-            CHECK(color.a == 0);
-        }
+        os << "(" << color.g << ")";
+        return os;
     }
-    GIVEN("A color_ga constructed with its overloaded constructor")
-    {
-        rl::color_ga<std::uint8_t> color(1, 2);
-        THEN("All properties are correct")
-        {
-            CHECK(color.g == 1);
-            CHECK(color.a == 2);
-        }
-    }
-}
 
-SCENARIO("Two color_ga are compared")
-{
-    GIVEN("A color_ga")
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_ga<C>& color)
     {
-        const rl::color_ga<std::uint8_t> color_a(24, 44);
-        GIVEN("Another color_ga that is equal")
-        {
-            const rl::color_ga<std::uint8_t> color_b(24, 44);
-            THEN("The color_ga are equal")
-            {
-                CHECK(color_a == color_b);
-            }
-        }
-        GIVEN("Another color_ga that is not equal")
-        {
-            const rl::color_ga<std::uint8_t> color_b(55, 128);
-            THEN("The color_ga are not equal")
-            {
-                CHECK(color_a != color_b);
-            }
-        }
+        os << "(" << color.g << ", " << color.a << ")";
+        return os;
     }
-}
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgb<C>& color)
+    {
+        os << "(" << color.r << ", " << color.g << ", " << color.b << ")";
+        return os;
+    }
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgba<C>& color)
+    {
+        os << "(" << color.r << ", " << color.g << ", " << color.b << ", " << color.a << ")";
+        return os;
+    }
+}    // namespace rl

--- a/include/rlm/color/detail/ostream.inl
+++ b/include/rlm/color/detail/ostream.inl
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <ostream>
+#include <type_traits>
 #include <rlm/color/concepts.hpp>
 #include <rlm/color/color_g.hpp>
 #include <rlm/color/color_ga.hpp>
@@ -34,28 +35,56 @@ namespace rl
     template<rl::color_channel C>
     constexpr std::ostream& operator<<(std::ostream& os, const rl::color_g<C>& color)
     {
-        os << "(" << color.g << ")";
+        if constexpr (std::is_same<C, unsigned char>::value || std::is_same<C, wchar_t>::value)
+        {
+            os << "(" << static_cast<unsigned int>(color.g) << ")";
+        }
+        else
+        {
+            os << "(" << color.g << ")";
+        }
         return os;
     }
 
     template<rl::color_channel C>
     constexpr std::ostream& operator<<(std::ostream& os, const rl::color_ga<C>& color)
     {
-        os << "(" << color.g << ", " << color.a << ")";
+        if constexpr (std::is_same<C, unsigned char>::value || std::is_same<C, wchar_t>::value)
+        {
+            os << "(" << static_cast<unsigned int>(color.g) << ", " << static_cast<unsigned int>(color.a) << ")";
+        }
+        else
+        {
+            os << "(" << color.g << ", " << color.a << ")";
+        }
         return os;
     }
 
     template<rl::color_channel C>
     constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgb<C>& color)
     {
-        os << "(" << color.r << ", " << color.g << ", " << color.b << ")";
+        if constexpr (std::is_same<C, unsigned char>::value || std::is_same<C, wchar_t>::value)
+        {
+            os << "(" << static_cast<unsigned int>(color.r) << ", " << static_cast<unsigned int>(color.g) << ", " << static_cast<unsigned int>(color.b) << ")";
+        }
+        else
+        {
+            os << "(" << color.r << ", " << color.g << ", " << color.b << ")";
+        }
         return os;
     }
 
     template<rl::color_channel C>
     constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgba<C>& color)
     {
-        os << "(" << color.r << ", " << color.g << ", " << color.b << ", " << color.a << ")";
+        if constexpr (std::is_same<C, unsigned char>::value || std::is_same<C, wchar_t>::value)
+        {
+            os << "(" << static_cast<unsigned int>(color.r) << ", " << static_cast<unsigned int>(color.g) << ", " << static_cast<unsigned int>(color.b) << ", " << static_cast<unsigned int>(color.a) << ")";
+        }
+        else
+        {
+            os << "(" << color.r << ", " << color.g << ", " << color.b << ", " << color.a << ")";
+        }
         return os;
     }
 }    // namespace rl

--- a/include/rlm/color/grayscale_conversion.hpp
+++ b/include/rlm/color/grayscale_conversion.hpp
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <rlm/color/concepts.hpp>
+
+namespace rl
+{
+    template<rl::color_channel C>
+    constexpr C rgb_to_grayscale_libpng(C r, C g, C b) noexcept;
+}
+
+#include <rlm/color/detail/grayscale_conversion.inl>

--- a/include/rlm/color/ostream.hpp
+++ b/include/rlm/color/ostream.hpp
@@ -20,51 +20,33 @@
     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <catch2/catch_all.hpp>
-#include <rlm/color/color_g.hpp>
-#include <rlm/color/ostream.hpp>
-#include <cstdint>
+#pragma once
 
-SCENARIO("A color_g is constructed")
-{
-    GIVEN("A color_g constructed with its default constructor")
-    {
-        rl::color_g<std::uint8_t> color;
-        THEN("All properties are correct")
-        {
-            CHECK(color.g == 0);
-        }
-    }
-    GIVEN("A color_g constructed with its overloaded constructor")
-    {
-        rl::color_g<std::uint8_t> color(1);
-        THEN("All properties are correct")
-        {
-            CHECK(color.g == 1);
-        }
-    }
-}
+#include <ostream>
+#include <rlm/color/concepts.hpp>
 
-SCENARIO("Two color_g are compared")
+namespace rl
 {
-    GIVEN("A color_g")
-    {
-        const rl::color_g<std::uint8_t> color_a(24);
-        GIVEN("Another color_g that is equal")
-        {
-            const rl::color_g<std::uint8_t> color_b(24);
-            THEN("The color_g are equal")
-            {
-                CHECK(color_a == color_b);
-            }
-        }
-        GIVEN("Another color_g that is not equal")
-        {
-            const rl::color_g<std::uint8_t> color_b(55);
-            THEN("The color_g are not equal")
-            {
-                CHECK(color_a != color_b);
-            }
-        }
-    }
-}
+    template<rl::color_channel C>
+    struct color_g;
+    template<rl::color_channel C>
+    struct color_ga;
+    template<rl::color_channel C>
+    struct color_rgb;
+    template<rl::color_channel C>
+    struct color_rgba;
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_g<C>& color);
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_ga<C>& color);
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgb<C>& color);
+
+    template<rl::color_channel C>
+    constexpr std::ostream& operator<<(std::ostream& os, const rl::color_rgba<C>& color);
+}    // namespace rl
+
+#include <rlm/color/detail/ostream.inl>

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(RlmTest
         "cellular_walk_tests.cpp"
         "color_color_channel_tests.cpp"
         "color_color_g_tests.cpp"
+        "color_color_ga_tests.cpp"
         "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(RlmTest
         "cellular_translation_tests.cpp"
         "cellular_walk_tests.cpp"
         "color_color_channel_tests.cpp"
+        "color_color_g_tests.cpp"
         "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(RlmTest
         "cellular_translation_tests.cpp"
         "cellular_walk_tests.cpp"
         "color_color_channel_tests.cpp"
+        "color_color_conversion_tests.cpp"
         "color_color_g_tests.cpp"
         "color_color_ga_tests.cpp"
         "color_color_rgb_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(RlmTest
         "cellular_translation_tests.cpp"
         "cellular_walk_tests.cpp"
         "color_color_channel_tests.cpp"
+        "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"
         "lerp_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(RlmTest
         "color_color_g_tests.cpp"
         "color_color_ga_tests.cpp"
         "color_color_rgb_tests.cpp"
+        "color_color_rgba_tests.cpp"
         "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(RlmTest
         "cellular_shape_points_tests.cpp"
         "cellular_translation_tests.cpp"
         "cellular_walk_tests.cpp"
+        "color_color_channel_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"
         "lerp_tests.cpp"

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(RlmTest
         "color_color_channel_tests.cpp"
         "color_color_g_tests.cpp"
         "color_color_ga_tests.cpp"
+        "color_color_rgb_tests.cpp"
         "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"

--- a/test/src/color_color_channel_tests.cpp
+++ b/test/src/color_color_channel_tests.cpp
@@ -66,6 +66,26 @@ SCENARIO("A color is casted to another channel type")
             }
         }
     }
+    GIVEN("A uint16_t channel")
+    {
+        const std::uint16_t channel = 65535;
+        WHEN("The channel is casted to a float")
+        {
+            const auto casted_channel = rl::color_channel_cast<float, std::uint16_t>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 1.0f);
+            }
+        }
+        WHEN("The channel is casted to a uint8_t")
+        {
+            const auto casted_channel = rl::color_channel_cast<std::uint8_t, std::uint16_t>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 255);
+            }
+        }
+    }
 }
 
 SCENARIO("The max value of a color channel is gotten")

--- a/test/src/color_color_channel_tests.cpp
+++ b/test/src/color_color_channel_tests.cpp
@@ -48,13 +48,13 @@ SCENARIO("A color is casted to another channel type")
     }
     GIVEN("An uint8_t channel")
     {
-        const std::uint8_t channel = 255;
+        const std::uint8_t channel = 127;
         WHEN("The channel is casted to a float")
         {
             const auto casted_channel = rl::color_channel_cast<float, std::uint8_t>(channel);
             THEN("The return value is correct")
             {
-                CHECK(casted_channel == 1.0f);
+                CHECK( (casted_channel> 0.49 && casted_channel < 0.51));
             }
         }
         WHEN("The channel is casted to a uin16_t")
@@ -62,19 +62,19 @@ SCENARIO("A color is casted to another channel type")
             const auto casted_channel = rl::color_channel_cast<std::uint16_t, std::uint8_t>(channel);
             THEN("The return value is correct")
             {
-                CHECK(casted_channel == 65535);
+                CHECK(casted_channel == 32639);
             }
         }
     }
     GIVEN("A uint16_t channel")
     {
-        const std::uint16_t channel = 65535;
+        const std::uint16_t channel = 32767;
         WHEN("The channel is casted to a float")
         {
             const auto casted_channel = rl::color_channel_cast<float, std::uint16_t>(channel);
             THEN("The return value is correct")
             {
-                CHECK(casted_channel == 1.0f);
+                CHECK( (casted_channel> 0.49 && casted_channel < 0.51));
             }
         }
         WHEN("The channel is casted to a uint8_t")

--- a/test/src/color_color_channel_tests.cpp
+++ b/test/src/color_color_channel_tests.cpp
@@ -82,7 +82,7 @@ SCENARIO("A color is casted to another channel type")
             const auto casted_channel = rl::color_channel_cast<std::uint8_t, std::uint16_t>(channel);
             THEN("The return value is correct")
             {
-                CHECK(casted_channel == 255);
+                CHECK(casted_channel == 128);
             }
         }
     }

--- a/test/src/color_color_channel_tests.cpp
+++ b/test/src/color_color_channel_tests.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_channel.hpp>
+#include <cstdint>
+
+SCENARIO("A color is casted to another channel type")
+{
+    GIVEN("A float color channel value")
+    {
+        const auto channel = 0.5f;
+        WHEN("The channel is casted to an uint8_t")
+        {
+            const auto casted_channel = rl::color_channel_cast<std::uint8_t, float>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 127);
+            }
+        }
+        WHEN("The channel is casted to a double")
+        {
+            const auto casted_channel = rl::color_channel_cast<double, float>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 0.5);
+            }
+        }
+    }
+    GIVEN("An uint8_t channel")
+    {
+        const std::uint8_t channel = 255;
+        WHEN("The channel is casted to a float")
+        {
+            const auto casted_channel = rl::color_channel_cast<float, std::uint8_t>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 1.0f);
+            }
+        }
+        WHEN("The channel is casted to a uin16_t")
+        {
+            const auto casted_channel = rl::color_channel_cast<std::uint16_t, std::uint8_t>(channel);
+            THEN("The return value is correct")
+            {
+                CHECK(casted_channel == 65535);
+            }
+        }
+    }
+}
+
+SCENARIO("The max value of a color channel is gotten")
+{
+    GIVEN("The max value of a float channel")
+    {
+        const auto max = rl::color_channel_max_value<float>();
+        THEN("The value is correct")
+        {
+            CHECK(max == 1.0f);
+        }
+    }
+    GIVEN("The max value of a uint8_t channel")
+    {
+        const auto max = rl::color_channel_max_value<std::uint8_t>();
+        THEN("The value is correct")
+        {
+            CHECK(max == 255);
+        }
+    }
+}
+
+SCENARIO("A color channel is clamped within the range of valid values")
+{
+    GIVEN("A float color channel that is out of range")
+    {
+        const auto channel = 433.44f;
+        WHEN("The float channel is clamped")
+        {
+            const auto clamped = rl::color_channel_clamp<float>(channel);
+            THEN("The clamped value is correct")
+            {
+                CHECK(clamped == 1.0f);
+            }
+        }
+    }
+}

--- a/test/src/color_color_conversion_tests.cpp
+++ b/test/src/color_color_conversion_tests.cpp
@@ -1,0 +1,1278 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_conversion.hpp>
+#include <rlm/color/ostream.hpp>
+#include <cstdint>
+
+SCENARIO("A color struct is converted")
+{
+    GIVEN("A rl::color_g<std::uint8_t>")
+    {
+        const rl::color_g<std::uint8_t> color(127);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32639, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32639, 32639, 32639, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        converted.a == 1.0
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_g<std::uint16_t>")
+    {
+        const rl::color_g<std::uint16_t> color(32767);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(128));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(128, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(128, 128, 128, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_g<double>")
+    {
+        const rl::color_g<double> color(0.5);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 65535));
+            }
+        }
+    }
+    GIVEN("A rl::color_ga<std::uint8_t>")
+    {
+        const rl::color_ga<std::uint8_t> color(127, 127);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32639, 32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_ga<std::uint16_t>")
+    {
+        const rl::color_ga<std::uint16_t> color(32767, 32767);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(128));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.4999 && converted.g < 0.51) &&
+                         (converted.a > 0.4999 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(128, 128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_ga<double>")
+    {
+        const rl::color_ga<double> color(0.5, 0.5);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 32767));
+            }
+        }
+    }
+    GIVEN("A rl::color_rgb<std::uint8_t>")
+    {
+        const rl::color_rgb<std::uint8_t> color(127, 127, 127);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32639, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32639, 32639, 32639, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        converted.a == 1.0
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_rgb<std::uint16_t>")
+    {
+        const rl::color_rgb<std::uint16_t> color(32767, 32767, 32767);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(128));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(128, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(128, 128, 128, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a == 1.0)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_rgb<double>")
+    {
+        const rl::color_rgb<double> color(0.5, 0.5, 0.5);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32765));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32765, 65535));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 255));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 65535));
+            }
+        }
+    }
+    GIVEN("A rl::color_rgba<std::uint8_t>")
+    {
+        const rl::color_rgba<std::uint8_t> color(127, 127, 127, 127);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint8_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32639, 32639, 32639, 32639));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint8_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_rgba<std::uint16_t>")
+    {
+        const rl::color_rgba<std::uint16_t> color(32767, 32767, 32767, 32767);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(128));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<double>")
+        {
+            const auto converted = rl::to_color_g<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.49 && converted.g < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<double>")
+        {
+            const auto converted = rl::to_color_ga<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.g > 0.4999 && converted.g < 0.51) &&
+                         (converted.a > 0.4999 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<double>")
+        {
+            const auto converted = rl::to_color_rgb<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51)
+                    )
+                );
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(128, 128, 128, 128));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, std::uint16_t>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<double>")
+        {
+            const auto converted = rl::to_color_rgba<double, std::uint16_t>(color);
+            THEN("The converted color value is correct")
+            {
+               CHECK(
+                    (
+                        (converted.r > 0.49 && converted.r < 0.51) &&
+                        (converted.g > 0.49 && converted.g < 0.51) &&
+                        (converted.b > 0.49 && converted.b < 0.51) &&
+                        (converted.a > 0.49 && converted.a < 0.51)
+                    )
+                );
+            }
+        }
+    }
+    GIVEN("A rl::color_rgba<double>")
+    {
+        const rl::color_rgba<double> color(0.5, 0.5, 0.5, 0.5);
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint8_t>(127));
+            }
+        }
+        WHEN("The color is converted to rl::color_g<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_g<std::uint16_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_g<std::uint16_t>(32765));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint8_t, double>(color);
+            THEN("The converted color value is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint8_t>(127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_ga<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_ga<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_ga<std::uint16_t>(32765, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint8_t>(127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgb<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgb<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgb<std::uint16_t>(32767, 32767, 32767));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint8_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint8_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint8_t>(127, 127, 127, 127));
+            }
+        }
+        WHEN("The color is converted to rl::color_rgba<std::uint16_t>")
+        {
+            const auto converted = rl::to_color_rgba<std::uint16_t, double>(color);
+            THEN("The converted color is correct")
+            {
+                CHECK(converted == rl::color_rgba<std::uint16_t>(32767, 32767, 32767, 32767));
+            }
+        }
+    }
+}

--- a/test/src/color_color_g_tests.cpp
+++ b/test/src/color_color_g_tests.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_g.hpp>
+#include <cstdint>
+
+SCENARIO("A color_g is constructed")
+{
+    GIVEN("A color_g constructed with its default constructor")
+    {
+        rl::color_g<std::uint8_t> color;
+        THEN("All properties are correct")
+        {
+            CHECK(color.g == 0);
+        }
+    }
+    GIVEN("A color_g constructed with its overloaded constructor")
+    {
+        rl::color_g<std::uint8_t> color(1);
+        THEN("All properties are correct")
+        {
+            CHECK(color.g == 1);
+        }
+    }
+}
+
+SCENARIO("Two color_g are compared")
+{
+    GIVEN("A color_g")
+    {
+        const rl::color_g<std::uint8_t> color_a(24);
+        GIVEN("Another color_g that is equal")
+        {
+            const rl::color_g<std::uint8_t> color_b(24);
+            THEN("The color_g are equal")
+            {
+                CHECK(color_a == color_b);
+            }
+        }
+        GIVEN("Another color_g that is not equal")
+        {
+            const rl::color_g<std::uint8_t> color_b(55);
+            THEN("The color_g are not equal")
+            {
+                CHECK(color_a != color_b);
+            }
+        }
+    }
+}

--- a/test/src/color_color_ga_tests.cpp
+++ b/test/src/color_color_ga_tests.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_ga.hpp>
+#include <cstdint>
+
+SCENARIO("A color_ga is constructed")
+{
+    GIVEN("A color_ga constructed with its default constructor")
+    {
+        rl::color_ga<std::uint8_t> color;
+        THEN("All properties are correct")
+        {
+            CHECK(color.g == 0);
+            CHECK(color.a == 0);
+        }
+    }
+    GIVEN("A color_ga constructed with its overloaded constructor")
+    {
+        rl::color_ga<std::uint8_t> color(1, 2);
+        THEN("All properties are correct")
+        {
+            CHECK(color.g == 1);
+            CHECK(color.a == 2);
+        }
+    }
+}
+
+SCENARIO("Two color_ga are compared")
+{
+    GIVEN("A color_ga")
+    {
+        const rl::color_ga<std::uint8_t> color_a(24, 44);
+        GIVEN("Another color_ga that is equal")
+        {
+            const rl::color_ga<std::uint8_t> color_b(24, 44);
+            THEN("The color_ga are equal")
+            {
+                CHECK(color_a == color_b);
+            }
+        }
+        GIVEN("Another color_ga that is not equal")
+        {
+            const rl::color_ga<std::uint8_t> color_b(55, 128);
+            THEN("The color_ga are not equal")
+            {
+                CHECK(color_a != color_b);
+            }
+        }
+    }
+}

--- a/test/src/color_color_rgb_tests.cpp
+++ b/test/src/color_color_rgb_tests.cpp
@@ -22,6 +22,7 @@
 
 #include <catch2/catch_all.hpp>
 #include <rlm/color/color_rgb.hpp>
+#include <rlm/color/ostream.hpp>
 #include <cstdint>
 
 SCENARIO("A color_rgb is constructed")

--- a/test/src/color_color_rgb_tests.cpp
+++ b/test/src/color_color_rgb_tests.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_rgb.hpp>
+#include <cstdint>
+
+SCENARIO("A color_rgb is constructed")
+{
+    GIVEN("A color_rgb constructed with its default constructor")
+    {
+        rl::color_rgb<std::uint8_t> color;
+        THEN("All properties are correct")
+        {
+            CHECK(color.r == 0);
+            CHECK(color.g == 0);
+            CHECK(color.b == 0);
+        }
+    }
+    GIVEN("A color_rgb constructed with its overloaded constructor")
+    {
+        rl::color_rgb<std::uint8_t> color(1, 2, 3);
+        THEN("All properties are correct")
+        {
+            CHECK(color.r == 1);
+            CHECK(color.g == 2);
+            CHECK(color.b == 3);
+        }
+    }
+}
+
+SCENARIO("Two color_rgb are compared")
+{
+    GIVEN("A color_rgb")
+    {
+        const rl::color_rgb<std::uint8_t> color_a(24, 44, 100);
+        GIVEN("Another color_rgb that is equal")
+        {
+            const rl::color_rgb<std::uint8_t> color_b(24, 44, 100);
+            THEN("The color_rgb are equal")
+            {
+                CHECK(color_a == color_b);
+            }
+        }
+        GIVEN("Another color_rgb that is not equal")
+        {
+            const rl::color_rgb<std::uint8_t> color_b(55, 128, 200);
+            THEN("The color_rgb are not equal")
+            {
+                CHECK(color_a != color_b);
+            }
+        }
+    }
+}

--- a/test/src/color_color_rgba_tests.cpp
+++ b/test/src/color_color_rgba_tests.cpp
@@ -22,6 +22,7 @@
 
 #include <catch2/catch_all.hpp>
 #include <rlm/color/color_rgba.hpp>
+#include <rlm/color/ostream.hpp>
 #include <cstdint>
 
 SCENARIO("A color_rgba is constructed")

--- a/test/src/color_color_rgba_tests.cpp
+++ b/test/src/color_color_rgba_tests.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/color_rgba.hpp>
+#include <cstdint>
+
+SCENARIO("A color_rgba is constructed")
+{
+    GIVEN("A color_rgba constructed with its default constructor")
+    {
+        rl::color_rgba<std::uint8_t> color;
+        THEN("All properties are correct")
+        {
+            CHECK(color.r == 0);
+            CHECK(color.g == 0);
+            CHECK(color.b == 0);
+            CHECK(color.a == 0);
+        }
+    }
+    GIVEN("A color_rgb constructed with its overloaded constructor")
+    {
+        rl::color_rgba<std::uint8_t> color(1, 2, 3, 4);
+        THEN("All properties are correct")
+        {
+            CHECK(color.r == 1);
+            CHECK(color.g == 2);
+            CHECK(color.b == 3);
+            CHECK(color.a == 4);
+        }
+    }
+}
+
+SCENARIO("Two color_rgba are compared")
+{
+    GIVEN("A color_rgba")
+    {
+        const rl::color_rgba<std::uint8_t> color_a(24, 44, 100, 244);
+        GIVEN("Another color_rgba that is equal")
+        {
+            const rl::color_rgba<std::uint8_t> color_b(24, 44, 100, 244);
+            THEN("The color_rgba are equal")
+            {
+                CHECK(color_a == color_b);
+            }
+        }
+        GIVEN("Another color_rgba that is not equal")
+        {
+            const rl::color_rgba<std::uint8_t> color_b(55, 128, 200, 255);
+            THEN("The color_rgba are not equal")
+            {
+                CHECK(color_a != color_b);
+            }
+        }
+    }
+}

--- a/test/src/color_grayscale_conversion_tests.cpp
+++ b/test/src/color_grayscale_conversion_tests.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/color/grayscale_conversion.hpp>
+#include <cstdint>
+
+SCENARIO("A rgb color components are converted to grayscale")
+{
+    GIVEN("Three float color components")
+    {
+        const auto r = 1.0f;
+        const auto g = 0.5f;
+        const auto b = 0.1f;
+        WHEN("The color components are converted to grayscale using the libpng method")
+        {
+            const auto grayscale = rl::rgb_to_grayscale_libpng<float>(r, g, b);
+            THEN("The grayscale value is correct")
+            {
+                CHECK((grayscale > 0.577f && grayscale < 0.578f));
+            }
+        }
+    }
+    GIVEN("Three uint8_t color components")
+    {
+        const std::uint8_t r = 255;
+        const std::uint8_t g = 184;
+        const std::uint8_t b = 53;
+        WHEN("The color components are converted to grayscale using the libpng method")
+        {
+            const auto grayscale = rl::rgb_to_grayscale_libpng<std::uint8_t>(r, g, b);
+            THEN("The grayscale value is correct")
+            {
+                CHECK(grayscale == 189);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description of Changes

Add color math types and functions. This will be crucial to the Roguelike Asset Library for image loading and manipulation. By  encapsulating all the color math in this library, it becomes easier to unit test. The color math will also be useful for roguelike games to define the background clear color and the foreground and background colors of each console tile. 

To keep things simple to start with, only conversions have been implemented along with a few utility functions for working with color channels that make the conversion functions easier to write. This portion of the library will be open for expansion in future updates.