### PR TITLE
Fix the hashing of structures

### DIFF
--- a/include/rlm/cellular/detail/hash.inl
+++ b/include/rlm/cellular/detail/hash.inl
@@ -53,7 +53,7 @@ namespace std
                 std::hash<I>{}(segment.start_x),
                 std::hash<I>{}(segment.start_y),
                 std::hash<I>{}(segment.end_x),
-                std::hash<I>{}(segment.end_y),
+                std::hash<I>{}(segment.end_y)
             );
     }
 

--- a/include/rlm/cellular/detail/hash.inl
+++ b/include/rlm/cellular/detail/hash.inl
@@ -74,9 +74,9 @@ namespace std
     {
         return 
             rl::hash_combine(
-                std::hash<C>{}(circle.x),
-                std::hash<C>{}(circle.y),
-                std::hash<C>{}(circle.radius)
+                std::hash<I>{}(circle.x),
+                std::hash<I>{}(circle.y),
+                std::hash<F>{}(circle.radius)
             );
     }
 

--- a/include/rlm/cellular/detail/pack_box.inl
+++ b/include/rlm/cellular/detail/pack_box.inl
@@ -32,7 +32,7 @@ constexpr rl::pack_box<I>::pack_box(unsigned int identifier, I width, I height) 
 }
 
 template<rl::signed_integral I>
-constexpr bool rl::pack_box<I>::operator==(const rl::pack_box<I>& that) noexcept
+constexpr bool rl::pack_box<I>::operator==(const rl::pack_box<I>& that) const noexcept
 {
     return
         this->identifier == that.identifier &&
@@ -41,7 +41,7 @@ constexpr bool rl::pack_box<I>::operator==(const rl::pack_box<I>& that) noexcept
 }
 
 template<rl::signed_integral I>
-constexpr bool rl::pack_box<I>::operator!=(const rl::pack_box<I>& that) noexcept
+constexpr bool rl::pack_box<I>::operator!=(const rl::pack_box<I>& that) const noexcept
 {
     return
         this->identifier != that.identifier &&

--- a/include/rlm/cellular/detail/pack_box.inl
+++ b/include/rlm/cellular/detail/pack_box.inl
@@ -30,3 +30,21 @@ constexpr rl::pack_box<I>::pack_box(unsigned int identifier, I width, I height) 
     , box(0, 0, width, height)
 {
 }
+
+template<rl::signed_integral I>
+constexpr bool rl::pack_box<I>::operator==(const rl::pack_box<I>& that) noexcept
+{
+    return
+        this->identifier == that.identifier &&
+        this->page == that.page &&
+        this->box == that.box;
+}
+
+template<rl::signed_integral I>
+constexpr bool rl::pack_box<I>::operator!=(const rl::pack_box<I>& that) noexcept
+{
+    return
+        this->identifier != that.identifier &&
+        this->page != that.page &&
+        this->box != that.box;
+}

--- a/include/rlm/cellular/detail/pack_box.inl
+++ b/include/rlm/cellular/detail/pack_box.inl
@@ -44,7 +44,7 @@ template<rl::signed_integral I>
 constexpr bool rl::pack_box<I>::operator!=(const rl::pack_box<I>& that) const noexcept
 {
     return
-        this->identifier != that.identifier &&
-        this->page != that.page &&
+        this->identifier != that.identifier ||
+        this->page != that.page ||
         this->box != that.box;
 }

--- a/include/rlm/cellular/detail/pack_space.inl
+++ b/include/rlm/cellular/detail/pack_space.inl
@@ -32,7 +32,7 @@ constexpr rl::pack_space<I>::pack_space(I x, I y, I width, I height, I page) noe
 }
 
 template<rl::signed_integral I>
-constexpr bool rl::pack_space<I>::operator==(const rl::pack_space<I>& that) noexcept
+constexpr bool rl::pack_space<I>::operator==(const rl::pack_space<I>& that) const noexcept
 {
     return
         this->page == that.page &&
@@ -40,7 +40,7 @@ constexpr bool rl::pack_space<I>::operator==(const rl::pack_space<I>& that) noex
 }
 
 template<rl::signed_integral I>
-constexpr bool rl::pack_space<I>::operator!=(const rl::pack_space<I>& that) noexcept
+constexpr bool rl::pack_space<I>::operator!=(const rl::pack_space<I>& that) const noexcept
 {
     return
         this->page != that.page &&

--- a/include/rlm/cellular/detail/pack_space.inl
+++ b/include/rlm/cellular/detail/pack_space.inl
@@ -30,3 +30,19 @@ constexpr rl::pack_space<I>::pack_space(I x, I y, I width, I height, I page) noe
     , page(page)
 {
 }
+
+template<rl::signed_integral I>
+constexpr bool rl::pack_space<I>::operator==(const rl::pack_space<I>& that) noexcept
+{
+    return
+        this->page == that.page &&
+        this->box == that.box;
+}
+
+template<rl::signed_integral I>
+constexpr bool rl::pack_space<I>::operator!=(const rl::pack_space<I>& that) noexcept
+{
+    return
+        this->page != that.page &&
+        this->box != that.box;
+}

--- a/include/rlm/cellular/detail/pack_space.inl
+++ b/include/rlm/cellular/detail/pack_space.inl
@@ -43,6 +43,6 @@ template<rl::signed_integral I>
 constexpr bool rl::pack_space<I>::operator!=(const rl::pack_space<I>& that) const noexcept
 {
     return
-        this->page != that.page &&
+        this->page != that.page ||
         this->box != that.box;
 }

--- a/include/rlm/cellular/pack_box.hpp
+++ b/include/rlm/cellular/pack_box.hpp
@@ -36,6 +36,9 @@ namespace rl
 
         constexpr pack_box() noexcept = default;
         constexpr pack_box(unsigned int identifier, I width, I height) noexcept;
+
+        constexpr bool operator==(const rl::pack_box<I>& that) noexcept;
+        constexpr bool operator!=(const rl::pack_box<I>& that) noexcept;
     };
 }    // namespace rl
 

--- a/include/rlm/cellular/pack_box.hpp
+++ b/include/rlm/cellular/pack_box.hpp
@@ -37,8 +37,8 @@ namespace rl
         constexpr pack_box() noexcept = default;
         constexpr pack_box(unsigned int identifier, I width, I height) noexcept;
 
-        constexpr bool operator==(const rl::pack_box<I>& that) noexcept;
-        constexpr bool operator!=(const rl::pack_box<I>& that) noexcept;
+        constexpr bool operator==(const rl::pack_box<I>& that) const noexcept;
+        constexpr bool operator!=(const rl::pack_box<I>& that) const noexcept;
     };
 }    // namespace rl
 

--- a/include/rlm/cellular/pack_space.hpp
+++ b/include/rlm/cellular/pack_space.hpp
@@ -36,8 +36,8 @@ namespace rl
         constexpr pack_space() noexcept = default;
         constexpr pack_space(I x, I y, I width, I height, I page) noexcept;
 
-        constexpr bool operator==(const rl::pack_space<I>& that) noexcept;
-        constexpr bool operator!=(const rl::pack_space<I>& that) noexcept;
+        constexpr bool operator==(const rl::pack_space<I>& that) const noexcept;
+        constexpr bool operator!=(const rl::pack_space<I>& that) const noexcept;
     };
 }    // namespace rl
 

--- a/include/rlm/cellular/pack_space.hpp
+++ b/include/rlm/cellular/pack_space.hpp
@@ -35,6 +35,9 @@ namespace rl
 
         constexpr pack_space() noexcept = default;
         constexpr pack_space(I x, I y, I width, I height, I page) noexcept;
+
+        constexpr bool operator==(const rl::pack_space<I>& that) noexcept;
+        constexpr bool operator!=(const rl::pack_space<I>& that) noexcept;
     };
 }    // namespace rl
 

--- a/include/rlm/detail/hash_combine.inl
+++ b/include/rlm/detail/hash_combine.inl
@@ -29,7 +29,7 @@ constexpr H rl::hash_combine(H hash_a, H hash_b) noexcept
 
 template<rl::unsigned_integral H, rl::unsigned_integral... Hs>
     requires std::conjunction_v<std::is_same<H, Hs>...>
-constexpr H hash_combine(const H hash_a, const H hash_b, const Hs... hash_n) noexcept
+constexpr H rl::hash_combine(const H hash_a, const H hash_b, const Hs... hash_n) noexcept
 {
     return
         rl::hash_combine(

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(RlmTest
         "color_grayscale_conversion_tests.cpp"
         "clamp_tests.cpp"
         "gcf_tests.cpp"
+        "hash_combine_tests.cpp"
         "lerp_tests.cpp"
         "linear_degenerate_shapes_tests.cpp"
         "linear_box2_tests.cpp"

--- a/test/src/cellular_pack_box_tests.cpp
+++ b/test/src/cellular_pack_box_tests.cpp
@@ -45,3 +45,29 @@ SCENARIO("A pack_box is constructed")
         }
     }
 }
+
+SCENARIO("Two pack_box are compared")
+{
+    GIVEN("A pack_box")
+    {
+        const rl::pack_box<int> box_a(1, 2, 3);
+        GIVEN("A pack_box that is the same")
+        {
+            const rl::pack_box<int> box_b(1, 2, 3);
+            THEN("The pack_box are equal")
+            {
+                CHECK(box_a == box_b);
+                CHECK_FALSE(box_a != box_b);
+            }
+        }
+        GIVEN("A pack_box that is different")
+        {
+            const rl::pack_box<int> box_b(3, 4, 5);
+            THEN("The pack_box are not equal")
+            {
+                CHECK_FALSE(box_a == box_b);
+                CHECK(box_a != box_b);
+            }
+        }
+    }
+}

--- a/test/src/cellular_pack_space_tests.cpp
+++ b/test/src/cellular_pack_space_tests.cpp
@@ -45,3 +45,29 @@ SCENARIO("A pack_space is constructed")
         }
     }
 }
+
+SCENARIO("Two pack_space are compared")
+{
+    GIVEN("A pack_space")
+    {
+        const rl::pack_space<int> box_a(1, 2, 3, 4, 5);
+        GIVEN("A pack_space that is the same")
+        {
+            const rl::pack_space<int> box_b(1, 2, 3, 4, 5);
+            THEN("The pack_space are equal")
+            {
+                CHECK(box_a == box_b);
+                CHECK_FALSE(box_a != box_b);
+            }
+        }
+        GIVEN("A pack_space that is different")
+        {
+            const rl::pack_space<int> box_b(3, 4, 5, 6, 7);
+            THEN("The pack_space are not equal")
+            {
+                CHECK_FALSE(box_a == box_b);
+                CHECK(box_a != box_b);
+            }
+        }
+    }
+}

--- a/test/src/hash_combine_tests.cpp
+++ b/test/src/hash_combine_tests.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2023 Daniel Aimé Valcour <fosssweeper@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+/*
+    Copyright (c) 2023 Daniel Aimé Valcour
+    Permission is hereby granted, free of charge, to any person obtaining a copy of
+    this software and associated documentation files (the "Software"), to deal in
+    the Software without restriction, including without limitation the rights to
+    use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+    the Software, and to permit persons to whom the Software is furnished to do so,
+    subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+    FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+    COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+    IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+    CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <catch2/catch_all.hpp>
+#include <rlm/hash_combine.hpp>
+#include <functional>
+
+SCENARIO("Multiple hashes are combined")
+{
+    GIVEN("Two hashes of two int values")
+    {
+        const auto hash_a = std::hash<int>{}(1234);
+        const auto hash_b = std::hash<int>{}(5678);
+        WHEN("The hashes are combined")
+        {
+            const auto combined_hash = rl::hash_combine(hash_a, hash_b);
+            THEN("The combined has does not match either of the two original hashes")
+            {
+                CHECK(combined_hash != hash_a);
+                CHECK(combined_hash != hash_b);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
# Description of Changes

Fix various syntax errors. Add comparison operator overloads to several struct so that they  can be used as a key to `std::unordered_map`